### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,5 @@ target/*.jar
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 image:https://travis-ci.com/spring-io/slackboot.svg?token=W7aHg1sSsP4krxEgwMRV&branch=master["Build Status", link="https://travis-ci.com/spring-io/slackboot"]
 
-This bot is used to help manage the guides and tutorials at http://spring.io/guides.
+This bot is used to help manage the guides and tutorials at https://spring.io/guides.
 
 This bot is also a nice demo app for building Slack bots.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://spring.io/guides with 1 occurrences migrated to:  
  https://spring.io/guides ([https](https://spring.io/guides) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).